### PR TITLE
$nodes as lowercase + data types

### DIFF
--- a/homie_spec/devices.py
+++ b/homie_spec/devices.py
@@ -59,7 +59,7 @@ class Device(NamedTuple):
 
         if self.nodes:
             payload_nodes = ",".join(self.nodes.keys())
-            yield msg("$nodes", payload_nodes)
+            yield msg("$nodes", payload_nodes.lower())
 
             for node_name, node in self.nodes.items():
                 node_prefix = "/".join((prefix, node_name))

--- a/homie_spec/nodes.py
+++ b/homie_spec/nodes.py
@@ -28,7 +28,8 @@ class Node(NamedTuple):
         yield msg("$type", self.typeOf)
 
         if self.properties:
-            yield msg("$properties", ",".join(self.properties.keys()))
+            payload_properties = ",".join(self.properties.keys())
+            yield msg("$properties", payload_properties.lower())
 
             for property_name, property_ in self.properties.items():
                 prop_prefix = "/".join((prefix, property_name))

--- a/tests/test_homie_devices.py
+++ b/tests/test_homie_devices.py
@@ -15,7 +15,7 @@ EXAMPLE_DEVICE = Device(id="mock", name="Mock Device")
 NODE1 = Node(name='light', typeOf='switch')
 NODE2 = Node(name='socket', typeOf='power')
 EXAMPLE_DEVICE_W_NODES = Device(id="mock", name="Mock Device",
-                                nodes={'light':NODE1, 'socket':NODE2})
+                                nodes={'Light':NODE1, 'Socket':NODE2})
 
 @given(devices())
 @example(device=EXAMPLE_DEVICE)
@@ -157,3 +157,16 @@ def test_node_path_inside_device(device: Device) -> None:
         for node in nodes:
             print(f"current path: {node['path']}")
             assert node['count'] == node_messages_count(node=node['obj'])
+
+@given(devices())
+@example(device=EXAMPLE_DEVICE_W_NODES)
+def test_nodes_lowercase(device: Device) -> None:
+    """check if $nodes are in lowercase
+    """
+    messages = list(device.messages())
+
+    for msg in messages:
+        if msg.topic.endswith('$nodes') and msg.payload:
+            assert msg.payload.islower()
+            #device.messages has only one $nodes topic
+            break

--- a/tests/test_homie_nodes.py
+++ b/tests/test_homie_nodes.py
@@ -85,12 +85,13 @@ def node_messages_count(node: Node) -> int:
     return count
 
 
-prop_light = Property(name="Mock light", datatype=Datatype.BOOLEAN, get=None)
-prop_color = Property(name="Mock color", datatype=Datatype.COLOR, get=None)
+PROP_LIGHT = Property(name="Mock light", datatype=Datatype.BOOLEAN, get=None)
+PROP_COLOR = Property(name="Mock color", datatype=Datatype.COLOR, get=None)
+EXAMPLE_NODE_W_PROPERTIES = Node(name="Mock Node", typeOf="mock",
+                   properties={'Light':PROP_LIGHT, 'Color':PROP_COLOR})
 
 @given(nodes(), text())
-@example(node=Node(name="Mock Node", typeOf="mock",
-                   properties={'light':prop_light, 'color':prop_color}), prefix="/homie/device")
+@example(node=EXAMPLE_NODE_W_PROPERTIES, prefix="/homie/device")
 def test_property_path_inside_node(node: Node, prefix:str) -> None:
     """check if the node porperties have the correct path
 
@@ -118,3 +119,14 @@ def test_property_path_inside_node(node: Node, prefix:str) -> None:
         for prop in props:
             print(f"current path: {prop['path']}")
             assert prop['count'] == property_message_count(prop=prop['obj'])
+
+@given(nodes(), text())
+@example(node=EXAMPLE_NODE_W_PROPERTIES, prefix="/homie/device")
+def test_properties_lowercase(node: Node, prefix:str) -> None:
+    """check if $properties are in lowercase
+    """
+    messages = list(node.messages(prefix))
+
+    for msg in messages:
+        if msg.topic.endswith('$properties') and msg.payload:
+            assert msg.payload.islower()


### PR DESCRIPTION
*modified $nodes and $properties output, so it's always lowercase #3
~+added data types defined in [homie v4](https://homieiot.github.io/specification/#payload) but not present in homie-spec~
+added/updated tests to reflect the code changes
~*updated documentation for the added data types~

All tests passed.

With these changes homie-spec works perfectly in my project, by the way thanks for the code.
Maybe you could create a new release and push it to pypi.